### PR TITLE
GM-55 채팅서버 온오프라인 API 연동

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,4 +15,4 @@ services:
       - "27017:27017"
     volumes:
       # -v 옵션 (다렉토리 마운트 설정)
-      - ~/data:/data/db
+      - ~/data/mongo/gaaji-market:/data/db

--- a/src/main/java/com/gaaji/chatmessage/domain/controller/ChatController.java
+++ b/src/main/java/com/gaaji/chatmessage/domain/controller/ChatController.java
@@ -2,6 +2,7 @@ package com.gaaji.chatmessage.domain.controller;
 
 import com.gaaji.chatmessage.domain.controller.dto.ChatRequest;
 import com.gaaji.chatmessage.domain.service.ChatService;
+import com.gaaji.chatmessage.global.constants.ApiConstants;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -15,7 +16,7 @@ public class ChatController {
 
     private final ChatService chatService;
 
-    @MessageMapping("/chats")
+    @MessageMapping(ApiConstants.ENDPOINT_CHAT)
     public void chat(@Payload ChatRequest chat) {
         log.info("CHAT: {}", chat);
 

--- a/src/main/java/com/gaaji/chatmessage/domain/controller/TokenController.java
+++ b/src/main/java/com/gaaji/chatmessage/domain/controller/TokenController.java
@@ -1,6 +1,7 @@
 package com.gaaji.chatmessage.domain.controller;
 
 import com.gaaji.chatmessage.domain.service.TokenService;
+import com.gaaji.chatmessage.global.constants.StringConstants;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,7 +23,7 @@ public class TokenController {
     public void createToken(HttpServletResponse response) {
         String token = tokenService.createToken();
 
-        response.addHeader("WebSocketToken", token);
+        response.addHeader(StringConstants.TOKEN_HEADER_KEY, token);
     }
 
 }

--- a/src/main/java/com/gaaji/chatmessage/domain/controller/TokenController.java
+++ b/src/main/java/com/gaaji/chatmessage/domain/controller/TokenController.java
@@ -1,6 +1,7 @@
 package com.gaaji.chatmessage.domain.controller;
 
 import com.gaaji.chatmessage.domain.service.TokenService;
+import com.gaaji.chatmessage.global.constants.ApiConstants;
 import com.gaaji.chatmessage.global.constants.StringConstants;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -13,12 +14,12 @@ import javax.servlet.http.HttpServletResponse;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/chats")
+@RequestMapping(ApiConstants.ENDPOINT_CHAT)
 public class TokenController {
 
     private final TokenService tokenService;
 
-    @GetMapping("/token")
+    @GetMapping(ApiConstants.ENDPOINT_CREATE_TOKEN)
     @ResponseStatus(HttpStatus.CREATED)
     public void createToken(HttpServletResponse response) {
         String token = tokenService.createToken();

--- a/src/main/java/com/gaaji/chatmessage/domain/service/ChatServiceImpl.java
+++ b/src/main/java/com/gaaji/chatmessage/domain/service/ChatServiceImpl.java
@@ -3,7 +3,7 @@ package com.gaaji.chatmessage.domain.service;
 import com.gaaji.chatmessage.domain.controller.dto.ChatRequest;
 import com.gaaji.chatmessage.domain.entity.Chat;
 import com.gaaji.chatmessage.domain.repository.ChatRepository;
-import com.gaaji.chatmessage.global.constants.StringConstants;
+import com.gaaji.chatmessage.global.constants.ApiConstants;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
@@ -30,6 +30,6 @@ public class ChatServiceImpl implements ChatService{
     }
 
     private void broadcasting(ChatRequest chat) {
-        template.convertAndSend(StringConstants.STOMP_SUB_URL + chat.getRoomId(), chat);
+        template.convertAndSend(ApiConstants.SUBSCRIBE_ENDPOINT + chat.getRoomId(), chat);
     }
 }

--- a/src/main/java/com/gaaji/chatmessage/domain/service/ChatServiceImpl.java
+++ b/src/main/java/com/gaaji/chatmessage/domain/service/ChatServiceImpl.java
@@ -3,6 +3,7 @@ package com.gaaji.chatmessage.domain.service;
 import com.gaaji.chatmessage.domain.controller.dto.ChatRequest;
 import com.gaaji.chatmessage.domain.entity.Chat;
 import com.gaaji.chatmessage.domain.repository.ChatRepository;
+import com.gaaji.chatmessage.global.constants.StringConstants;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
@@ -11,7 +12,6 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ChatServiceImpl implements ChatService{
 
-    private static final String SUB_URL = "/sub/chat/room/";
     private final SimpMessageSendingOperations template;
     private final ChatRepository chatRepository;
 
@@ -30,6 +30,6 @@ public class ChatServiceImpl implements ChatService{
     }
 
     private void broadcasting(ChatRequest chat) {
-        template.convertAndSend(SUB_URL + chat.getRoomId(), chat);
+        template.convertAndSend(StringConstants.STOMP_SUB_URL + chat.getRoomId(), chat);
     }
 }

--- a/src/main/java/com/gaaji/chatmessage/global/config/WebSocketConfig.java
+++ b/src/main/java/com/gaaji/chatmessage/global/config/WebSocketConfig.java
@@ -1,5 +1,6 @@
 package com.gaaji.chatmessage.global.config;
 
+import com.gaaji.chatmessage.global.constants.ApiConstants;
 import com.gaaji.chatmessage.global.stomp.StompErrorHandler;
 import com.gaaji.chatmessage.global.stomp.StompHandler;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +21,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/ws/gaaji-chat")
+        registry.addEndpoint(ApiConstants.WEBSOCKET_ENDPOINT)
                 .setAllowedOriginPatterns("*");
         // Heartbeat 고려
         // withSockJS()는 JS 라이브러리인 SockJS를 사용한다는 함수로,
@@ -31,9 +32,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry.enableSimpleBroker("/sub");
+        registry.enableSimpleBroker(ApiConstants.WEBSOCKET_SUBSCRIBE_ENDPOINT);
 
-        registry.setApplicationDestinationPrefixes("/pub");
+        registry.setApplicationDestinationPrefixes(ApiConstants.WEBSOCKET_PUBLISH_ENDPOINT);
     }
 
     @Override

--- a/src/main/java/com/gaaji/chatmessage/global/constants/ApiConstants.java
+++ b/src/main/java/com/gaaji/chatmessage/global/constants/ApiConstants.java
@@ -1,0 +1,10 @@
+package com.gaaji.chatmessage.global.constants;
+
+public class ApiConstants {
+    public static final String WEBSOCKET_ENDPOINT = "/ws/gaaji-chat";
+    public static final String WEBSOCKET_PUBLISH_ENDPOINT = "/pub";
+    public static final String WEBSOCKET_SUBSCRIBE_ENDPOINT = "/sub";
+    public static final String SUBSCRIBE_ENDPOINT = WEBSOCKET_SUBSCRIBE_ENDPOINT + "/chat/room/";
+    public static final String ENDPOINT_CHAT = "/chats";
+    public static final String ENDPOINT_CREATE_TOKEN = "/token";
+}

--- a/src/main/java/com/gaaji/chatmessage/global/constants/StringConstants.java
+++ b/src/main/java/com/gaaji/chatmessage/global/constants/StringConstants.java
@@ -2,11 +2,7 @@ package com.gaaji.chatmessage.global.constants;
 
 public class StringConstants {
 
-    /** Token Prefix */
     public static final String BEARER_PREFIX = "Bearer ";
-    /** WebSocket Token Header Key */
     public static final String TOKEN_HEADER_KEY = "WebSocketToken";
-    /** Stomp Subscribe Url */
-    public static final String STOMP_SUB_URL = "/sub/chat/room/";
 
 }

--- a/src/main/java/com/gaaji/chatmessage/global/constants/StringConstants.java
+++ b/src/main/java/com/gaaji/chatmessage/global/constants/StringConstants.java
@@ -1,0 +1,12 @@
+package com.gaaji.chatmessage.global.constants;
+
+public class StringConstants {
+
+    /** Token Prefix */
+    public static final String BEARER_PREFIX = "Bearer ";
+    /** WebSocket Token Header Key */
+    public static final String TOKEN_HEADER_KEY = "WebSocketToken";
+    /** Stomp Subscribe Url */
+    public static final String STOMP_SUB_URL = "/sub/chat/room/";
+
+}

--- a/src/main/java/com/gaaji/chatmessage/global/jwt/JwtProvider.java
+++ b/src/main/java/com/gaaji/chatmessage/global/jwt/JwtProvider.java
@@ -1,5 +1,6 @@
 package com.gaaji.chatmessage.global.jwt;
 
+import com.gaaji.chatmessage.global.constants.StringConstants;
 import com.gaaji.chatmessage.global.exception.ErrorCodeConstants;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
@@ -27,8 +28,6 @@ public class JwtProvider {
     private String secretKey;
     private static final long EXPIRATION_SECOND = 300; // 5 min.
 
-    private static final String BEARER_PREFIX = "Bearer ";
-
     @PostConstruct
     protected void init() {
         secretKey = Base64.encodeBase64String(secretKey.getBytes(StandardCharsets.UTF_8));
@@ -47,7 +46,7 @@ public class JwtProvider {
 
     public String createToken() {
         log.info("[JwtProvider] - Token Creating ...");
-        return BEARER_PREFIX + createToken(EXPIRATION_SECOND);
+        return StringConstants.BEARER_PREFIX + createToken(EXPIRATION_SECOND);
     }
 
     public void validateToken(String token) {
@@ -55,11 +54,11 @@ public class JwtProvider {
             throw new MessageDeliveryException(ErrorCodeConstants.JWT_NULL);
         }
 
-        if (!token.contains(BEARER_PREFIX)) {
+        if (!token.contains(StringConstants.BEARER_PREFIX)) {
             throw new MessageDeliveryException(ErrorCodeConstants.JWT_INVALIDATED_PREFIX);
         }
 
-        token = token.substring(BEARER_PREFIX.length());
+        token = token.substring(StringConstants.BEARER_PREFIX.length());
 
         Jws<Claims> claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
         if (claims.getBody() == null) {

--- a/src/main/java/com/gaaji/chatmessage/global/stomp/StompHandler.java
+++ b/src/main/java/com/gaaji/chatmessage/global/stomp/StompHandler.java
@@ -1,5 +1,6 @@
 package com.gaaji.chatmessage.global.stomp;
 
+import com.gaaji.chatmessage.domain.service.KafkaService;
 import com.gaaji.chatmessage.global.exception.ErrorCodeConstants;
 import com.gaaji.chatmessage.global.jwt.JwtProvider;
 import io.jsonwebtoken.ExpiredJwtException;

--- a/src/main/java/com/gaaji/chatmessage/global/stomp/StompHandler.java
+++ b/src/main/java/com/gaaji/chatmessage/global/stomp/StompHandler.java
@@ -1,5 +1,6 @@
 package com.gaaji.chatmessage.global.stomp;
 
+import com.gaaji.chatmessage.global.constants.StringConstants;
 import com.gaaji.chatmessage.global.exception.ErrorCodeConstants;
 import com.gaaji.chatmessage.global.jwt.JwtProvider;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -19,7 +20,6 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class StompHandler implements ChannelInterceptor {
 
-    private static final String BEARER_PREFIX = "Bearer ";
     private final JwtProvider jwtProvider;
 
     @Override
@@ -33,7 +33,7 @@ public class StompHandler implements ChannelInterceptor {
 
             log.info("[StompHandler] - Token Validating ...");
 
-            String authorization = accessor.getFirstNativeHeader("WebSocketToken");
+            String authorization = accessor.getFirstNativeHeader(StringConstants.TOKEN_HEADER_KEY);
             try {
                 jwtProvider.validateToken(authorization);
 


### PR DESCRIPTION
# Description
GM-69 하위의 GM-55 '채팅서버 온오프라인 api 연동' 이슈에 대한 PR.
본래 이슈 내용을 GM-90에서 처리하여 본 PR에서 해당 로직에 관련된 내용을 추가, 수정하지 않았다.
다만, 본 PR에서는 Refactoring을 진행하였다.

## Refactoring
- `StringConstants` : 전역적으로 사용하는 String 변수 관리
```
    public static final String BEARER_PREFIX = "Bearer ";
    public static final String TOKEN_HEADER_KEY = "WebSocketToken";
```
- `ApiConstants` : API Endpoint 관리
```
    public static final String WEBSOCKET_ENDPOINT = "/ws/gaaji-chat";
    public static final String WEBSOCKET_PUBLISH_ENDPOINT = "/pub";
    public static final String WEBSOCKET_SUBSCRIBE_ENDPOINT = "/sub";
    public static final String SUBSCRIBE_ENDPOINT = WEBSOCKET_SUBSCRIBE_ENDPOINT + "/chat/room/";
    public static final String ENDPOINT_CHAT = "/chats";
    public static final String ENDPOINT_CREATE_TOKEN = "/token";
```