### PR TITLE
[GM-97] Disconnect 중복 호출 이슈

### DIFF
--- a/src/main/java/com/gaaji/chatmessage/domain/controller/TokenController.java
+++ b/src/main/java/com/gaaji/chatmessage/domain/controller/TokenController.java
@@ -24,7 +24,7 @@ public class TokenController {
     public void createToken(HttpServletResponse response) {
         String token = tokenService.createToken();
 
-        response.addHeader(StringConstants.TOKEN_HEADER_KEY, token);
+        response.addHeader(StringConstants.SOCKET_TOKEN_HEADER_KEY, token);
     }
 
 }

--- a/src/main/java/com/gaaji/chatmessage/domain/controller/TokenController.java
+++ b/src/main/java/com/gaaji/chatmessage/domain/controller/TokenController.java
@@ -24,7 +24,7 @@ public class TokenController {
     public void createToken(HttpServletResponse response) {
         String token = tokenService.createToken();
 
-        response.addHeader(StringConstants.SOCKET_TOKEN_HEADER_KEY, token);
+        response.addHeader(StringConstants.HEADER_SOCKET_TOKEN, token);
     }
 
 }

--- a/src/main/java/com/gaaji/chatmessage/domain/controller/dto/kafka/ConnectStatusRequest.java
+++ b/src/main/java/com/gaaji/chatmessage/domain/controller/dto/kafka/ConnectStatusRequest.java
@@ -11,20 +11,20 @@ public class ConnectStatusRequest {
     private String userId;
     private String status;
 
-    public ConnectStatusRequest setStatus(String status) {
+    private ConnectStatusRequest setStatus(String status) {
         this.status = status;
         return this;
     }
 
-    private static ConnectStatusRequest of(String userId) {
+    private static ConnectStatusRequest from(String userId) {
         return ConnectStatusRequest.builder().userId(userId).build();
     }
 
-    public static ConnectStatusRequest ofOnline(String userId) {
-        return of(userId).setStatus(ONLINE);
+    public static ConnectStatusRequest newOnline(String userId) {
+        return ConnectStatusRequest.from(userId).setStatus(ONLINE);
     }
 
-    public static ConnectStatusRequest ofOffLine(String userId) {
-        return of(userId).setStatus(OFFLINE);
+    public static ConnectStatusRequest newOffline(String userId) {
+        return ConnectStatusRequest.from(userId).setStatus(OFFLINE);
     }
 }

--- a/src/main/java/com/gaaji/chatmessage/domain/controller/dto/kafka/ConnectStatusRequest.java
+++ b/src/main/java/com/gaaji/chatmessage/domain/controller/dto/kafka/ConnectStatusRequest.java
@@ -6,6 +6,8 @@ import lombok.Data;
 @Data
 @Builder
 public class ConnectStatusRequest {
+    private static final String ONLINE = "ONLINE";
+    private static final String OFFLINE = "OFFLINE";
     private String userId;
     private String status;
 
@@ -19,10 +21,10 @@ public class ConnectStatusRequest {
     }
 
     public static ConnectStatusRequest ofOnline(String userId) {
-        return of(userId).setStatus("ONLINE");
+        return of(userId).setStatus(ONLINE);
     }
 
     public static ConnectStatusRequest ofOffLine(String userId) {
-        return of(userId).setStatus("OFFLINE");
+        return of(userId).setStatus(OFFLINE);
     }
 }

--- a/src/main/java/com/gaaji/chatmessage/domain/service/KafkaServiceImpl.java
+++ b/src/main/java/com/gaaji/chatmessage/domain/service/KafkaServiceImpl.java
@@ -18,13 +18,13 @@ public class KafkaServiceImpl implements KafkaService {
 
     @Override
     public void notifyOnline(String userId) {
-        ConnectStatusRequest online = ConnectStatusRequest.ofOnline(userId);
+        ConnectStatusRequest online = ConnectStatusRequest.newOnline(userId);
         notifyStatus(online);
     }
 
     @Override
     public void notifyOffline(String userId) {
-        ConnectStatusRequest offline = ConnectStatusRequest.ofOffLine(userId);
+        ConnectStatusRequest offline = ConnectStatusRequest.newOffline(userId);
         notifyStatus(offline);
     }
 

--- a/src/main/java/com/gaaji/chatmessage/domain/service/KafkaServiceImpl.java
+++ b/src/main/java/com/gaaji/chatmessage/domain/service/KafkaServiceImpl.java
@@ -28,6 +28,11 @@ public class KafkaServiceImpl implements KafkaService {
         notifyStatus(offline);
     }
 
+    private void notifyStatus(ConnectStatusRequest status) {
+        String message = convertValueAsString(status);
+        sendMessage("status", message);
+    }
+
     @Override
     public void chat(ChatRequest chat) {
         String message = convertValueAsString(chat);
@@ -37,11 +42,6 @@ public class KafkaServiceImpl implements KafkaService {
     private void sendMessage(String topic, String message) {
         log.info("Send kafka Message: topic - {}, message - {}", topic, message);
         this.kafkaTemplate.send(topic, message);
-    }
-
-    private void notifyStatus(ConnectStatusRequest status) {
-        String message = convertValueAsString(status);
-        sendMessage("status", message);
     }
 
     private String convertValueAsString(Object value) {

--- a/src/main/java/com/gaaji/chatmessage/domain/service/KafkaServiceImpl.java
+++ b/src/main/java/com/gaaji/chatmessage/domain/service/KafkaServiceImpl.java
@@ -7,10 +7,10 @@ import com.gaaji.chatmessage.domain.controller.dto.kafka.ConnectStatusRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 @Slf4j
-@Service
+@Component
 @RequiredArgsConstructor
 public class KafkaServiceImpl implements KafkaService {
 

--- a/src/main/java/com/gaaji/chatmessage/domain/service/WebSocketConnectService.java
+++ b/src/main/java/com/gaaji/chatmessage/domain/service/WebSocketConnectService.java
@@ -1,0 +1,6 @@
+package com.gaaji.chatmessage.domain.service;
+
+public interface WebSocketConnectService {
+    void connect(String sessionId, String userId);
+    void disconnect(String sessionId);
+}

--- a/src/main/java/com/gaaji/chatmessage/domain/service/WebSocketConnectServiceImpl.java
+++ b/src/main/java/com/gaaji/chatmessage/domain/service/WebSocketConnectServiceImpl.java
@@ -1,0 +1,31 @@
+package com.gaaji.chatmessage.domain.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class WebSocketConnectServiceImpl implements WebSocketConnectService {
+
+    private static Map<String, String> sessions = new HashMap<>();
+    private final KafkaService kafkaService;
+
+    @Override
+    public void connect(String sessionId, String userId) {
+        sessions.put(sessionId, userId);
+
+        kafkaService.notifyOnline(userId);
+    }
+
+    @Override
+    public void disconnect(String sessionId) {
+        if( sessions.containsKey(sessionId) ) {
+            String userId = sessions.remove(sessionId);
+
+            kafkaService.notifyOffline(userId);
+        }
+    }
+}

--- a/src/main/java/com/gaaji/chatmessage/global/constants/StringConstants.java
+++ b/src/main/java/com/gaaji/chatmessage/global/constants/StringConstants.java
@@ -3,6 +3,7 @@ package com.gaaji.chatmessage.global.constants;
 public class StringConstants {
 
     public static final String BEARER_PREFIX = "Bearer ";
-    public static final String SOCKET_TOKEN_HEADER_KEY = "WebSocketToken";
+    public static final String HEADER_SOCKET_TOKEN = "WebSocketToken";
+    public static final String HEADER_AUTH_ID = "AuthId";
 
 }

--- a/src/main/java/com/gaaji/chatmessage/global/constants/StringConstants.java
+++ b/src/main/java/com/gaaji/chatmessage/global/constants/StringConstants.java
@@ -3,6 +3,6 @@ package com.gaaji.chatmessage.global.constants;
 public class StringConstants {
 
     public static final String BEARER_PREFIX = "Bearer ";
-    public static final String TOKEN_HEADER_KEY = "WebSocketToken";
+    public static final String SOCKET_TOKEN_HEADER_KEY = "WebSocketToken";
 
 }

--- a/src/main/java/com/gaaji/chatmessage/global/jwt/JwtProvider.java
+++ b/src/main/java/com/gaaji/chatmessage/global/jwt/JwtProvider.java
@@ -2,10 +2,7 @@ package com.gaaji.chatmessage.global.jwt;
 
 import com.gaaji.chatmessage.global.constants.StringConstants;
 import com.gaaji.chatmessage.global.exception.ErrorCodeConstants;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jws;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.tomcat.util.codec.binary.Base64;
@@ -49,20 +46,44 @@ public class JwtProvider {
         return StringConstants.BEARER_PREFIX + createToken(EXPIRATION_SECOND);
     }
 
-    public void validateToken(String token) {
+    public void validateToken(String inputToken) {
+        log.info("[JwtProvider] - Token Validating ...");
+
+        String token;
+        token = validateTokenIsNonNull(inputToken);
+        token = validateTokenHasPrefix(token);
+
+        try {
+            Jws<Claims> claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
+
+            validateTokenInvalidated(claims);
+
+        } catch (MalformedJwtException e ) {
+            throw new MessageDeliveryException(ErrorCodeConstants.JWT_MALFORMED);
+
+        } catch (ExpiredJwtException e) {
+            throw new MessageDeliveryException(ErrorCodeConstants.JWT_EXPIRED);
+        }
+    }
+
+    private String validateTokenIsNonNull(String token) {
         if(!StringUtils.hasText(token)) {
             throw new MessageDeliveryException(ErrorCodeConstants.JWT_NULL);
         }
+        return token;
+    }
 
+    private String validateTokenHasPrefix(String token) {
         if (!token.contains(StringConstants.BEARER_PREFIX)) {
             throw new MessageDeliveryException(ErrorCodeConstants.JWT_INVALIDATED_PREFIX);
         }
+        return token.substring(StringConstants.BEARER_PREFIX.length());
+    }
 
-        token = token.substring(StringConstants.BEARER_PREFIX.length());
-
-        Jws<Claims> claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
+    private void validateTokenInvalidated(Jws<Claims> claims) {
         if (claims.getBody() == null) {
             throw new MessageDeliveryException(ErrorCodeConstants.JWT_INVALIDATED);
         }
     }
+
 }

--- a/src/main/java/com/gaaji/chatmessage/global/jwt/JwtProvider.java
+++ b/src/main/java/com/gaaji/chatmessage/global/jwt/JwtProvider.java
@@ -58,6 +58,8 @@ public class JwtProvider {
 
             validateTokenInvalidated(claims);
 
+            log.info("[JwtProvider] - Token Validated.");
+
         } catch (MalformedJwtException e ) {
             throw new MessageDeliveryException(ErrorCodeConstants.JWT_MALFORMED);
 


### PR DESCRIPTION
# Description
> GM-69 하위의 GM-97 이슈에 대한 PR임.

GM-97 이슈 발행 목적은 Disconnect 중복호출로 인한 유저 온라인 상태를 알리는 kafka 메시지가  

중복하여 발행되는 문제가 발생하여, 이를 해결하기 위함이다.

## Issue
Disconnect 중복 호출의 근본적인 해결을 하진 못하였음.  

다만, Session ID와 User ID를 저장하는 Map 객체를 생성하여,  

Connect 시 Map에 put, Disconnect 시 remove하여 connect 유저 세션을 관리하도록 함.  

이에 Disconnect 중복 호출 시 Map에서 Session ID를 조회하고, 

존재하면 Map에서 삭제하고, Kafka 메시지를 발행, 전송

존재하지 않으면 상기 로직이 무시된다.

## Related Class
`global.stomp.StompHandler`

`domain.service.WebSocketConnectService`

`domain.service.WebSocketConnectServiceImpl`

## 고려해볼만한 이슈
상기 설명한 Map 객체를 Repository에 저장하도록 할지..

NoSQL인 MongoDB를 사용하지만, Create, Delete가 빈번한 데이터에 대해 적합할지...

계속 고민해보겠음;
