### PR TITLE
[GM-107] 에러코드 재설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,10 @@ repositories {
     mavenCentral()
 }
 
+ext {
+    set('springCloudVersion', "2021.0.5")
+}
+
 dependencies {
     // Web Dependencies
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -36,6 +40,9 @@ dependencies {
     implementation 'org.springframework.kafka:spring-kafka'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
 
+    // eureka
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
@@ -46,6 +53,13 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
 }
 
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
+}
+
 tasks.named('test') {
     useJUnitPlatform()
 }
+

--- a/src/main/java/com/gaaji/chatmessage/domain/controller/dto/ConnectStatusRequest.java
+++ b/src/main/java/com/gaaji/chatmessage/domain/controller/dto/ConnectStatusRequest.java
@@ -1,4 +1,4 @@
-package com.gaaji.chatmessage.domain.controller.dto.kafka;
+package com.gaaji.chatmessage.domain.controller.dto;
 
 import lombok.Builder;
 import lombok.Data;

--- a/src/main/java/com/gaaji/chatmessage/domain/service/KafkaServiceImpl.java
+++ b/src/main/java/com/gaaji/chatmessage/domain/service/KafkaServiceImpl.java
@@ -3,7 +3,7 @@ package com.gaaji.chatmessage.domain.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gaaji.chatmessage.domain.controller.dto.ChatRequest;
-import com.gaaji.chatmessage.domain.controller.dto.kafka.ConnectStatusRequest;
+import com.gaaji.chatmessage.domain.controller.dto.ConnectStatusRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;

--- a/src/main/java/com/gaaji/chatmessage/global/exception/ErrorCode.java
+++ b/src/main/java/com/gaaji/chatmessage/global/exception/ErrorCode.java
@@ -1,18 +1,18 @@
 package com.gaaji.chatmessage.global.exception;
 
 public enum ErrorCode {
-    TOKEN_NULL_ERROR(401, "인증 토큰이 없습니다."),
-    INVALIDATED_TOKEN_ERROR(401, "토큰 검증에 실패하였습니다."),
-    MALFORMED_TOKEN_ERROR(401, "토큰의 형식이 유효하지 않습니다."),
-    TOKEN_EXPIRATION_ERROR(401, "인증 토큰이 만료되었습니다."),
-    INVALIDATED_TOKEN_PREFIX_ERROR(401, "토큰 타입이 유효하지 않습니다."),
+    TOKEN_NULL_ERROR("C-101", "인증 토큰이 없습니다."),
+    INVALIDATED_TOKEN_ERROR("C-102", "토큰 검증에 실패하였습니다."),
+    MALFORMED_TOKEN_ERROR("C-103", "토큰의 형식이 유효하지 않습니다."),
+    TOKEN_EXPIRATION_ERROR("C-104", "인증 토큰이 만료되었습니다."),
+    INVALIDATED_TOKEN_PREFIX_ERROR("C-105", "토큰 타입이 유효하지 않습니다."),
     ;
-    private int code;
+    private String code;
     private String message;
-    ErrorCode(int code, String message) {
+    ErrorCode(String code, String message) {
         this.code = code;
         this.message = message;
     }
-    public int getCode() { return code; }
+    public String getCode() { return code; }
     public String getMessage() { return message; }
 }

--- a/src/main/java/com/gaaji/chatmessage/global/exception/ExceptionHandlerConstants.java
+++ b/src/main/java/com/gaaji/chatmessage/global/exception/ExceptionHandlerConstants.java
@@ -1,6 +1,6 @@
 package com.gaaji.chatmessage.global.exception;
 
-public class ErrorCodeConstants {
+public class ExceptionHandlerConstants {
     public static final String JWT_NULL = "JWT_NULL";
     public static final String JWT_INVALIDATED = "JWT_INVALIDATED";
     public static final String JWT_MALFORMED = "JWT_MALFORMED";

--- a/src/main/java/com/gaaji/chatmessage/global/jwt/JwtProvider.java
+++ b/src/main/java/com/gaaji/chatmessage/global/jwt/JwtProvider.java
@@ -1,7 +1,7 @@
 package com.gaaji.chatmessage.global.jwt;
 
 import com.gaaji.chatmessage.global.constants.StringConstants;
-import com.gaaji.chatmessage.global.exception.ErrorCodeConstants;
+import com.gaaji.chatmessage.global.exception.ExceptionHandlerConstants;
 import io.jsonwebtoken.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -61,30 +61,30 @@ public class JwtProvider {
             log.info("[JwtProvider] - Token Validated.");
 
         } catch (MalformedJwtException e ) {
-            throw new MessageDeliveryException(ErrorCodeConstants.JWT_MALFORMED);
+            throw new MessageDeliveryException(ExceptionHandlerConstants.JWT_MALFORMED);
 
         } catch (ExpiredJwtException e) {
-            throw new MessageDeliveryException(ErrorCodeConstants.JWT_EXPIRED);
+            throw new MessageDeliveryException(ExceptionHandlerConstants.JWT_EXPIRED);
         }
     }
 
     private String validateTokenIsNonNull(String token) {
         if(!StringUtils.hasText(token)) {
-            throw new MessageDeliveryException(ErrorCodeConstants.JWT_NULL);
+            throw new MessageDeliveryException(ExceptionHandlerConstants.JWT_NULL);
         }
         return token;
     }
 
     private String validateTokenHasPrefix(String token) {
         if (!token.contains(StringConstants.BEARER_PREFIX)) {
-            throw new MessageDeliveryException(ErrorCodeConstants.JWT_INVALIDATED_PREFIX);
+            throw new MessageDeliveryException(ExceptionHandlerConstants.JWT_INVALIDATED_PREFIX);
         }
         return token.substring(StringConstants.BEARER_PREFIX.length());
     }
 
     private void validateTokenInvalidated(Jws<Claims> claims) {
         if (claims.getBody() == null) {
-            throw new MessageDeliveryException(ErrorCodeConstants.JWT_INVALIDATED);
+            throw new MessageDeliveryException(ExceptionHandlerConstants.JWT_INVALIDATED);
         }
     }
 

--- a/src/main/java/com/gaaji/chatmessage/global/stomp/StompErrorHandler.java
+++ b/src/main/java/com/gaaji/chatmessage/global/stomp/StompErrorHandler.java
@@ -1,7 +1,7 @@
 package com.gaaji.chatmessage.global.stomp;
 
 import com.gaaji.chatmessage.global.exception.ErrorCode;
-import com.gaaji.chatmessage.global.exception.ErrorCodeConstants;
+import com.gaaji.chatmessage.global.exception.ExceptionHandlerConstants;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageDeliveryException;
@@ -31,19 +31,19 @@ public class StompErrorHandler extends StompSubProtocolErrorHandler {
         if (ex instanceof MessageDeliveryException) {
 
             switch (Objects.requireNonNull(ex.getMessage())) {
-                case ErrorCodeConstants.JWT_NULL:
+                case ExceptionHandlerConstants.JWT_NULL:
                     return handleTokenException(ErrorCode.TOKEN_NULL_ERROR);
 
-                case ErrorCodeConstants.JWT_INVALIDATED:
+                case ExceptionHandlerConstants.JWT_INVALIDATED:
                     return handleTokenException(ErrorCode.INVALIDATED_TOKEN_ERROR);
 
-                case ErrorCodeConstants.JWT_EXPIRED:
+                case ExceptionHandlerConstants.JWT_EXPIRED:
                     return handleTokenException(ErrorCode.TOKEN_EXPIRATION_ERROR);
 
-                case ErrorCodeConstants.JWT_MALFORMED:
+                case ExceptionHandlerConstants.JWT_MALFORMED:
                     return handleTokenException(ErrorCode.MALFORMED_TOKEN_ERROR);
 
-                case ErrorCodeConstants.JWT_INVALIDATED_PREFIX:
+                case ExceptionHandlerConstants.JWT_INVALIDATED_PREFIX:
                     return handleTokenException(ErrorCode.INVALIDATED_TOKEN_PREFIX_ERROR);
             }
         }
@@ -59,16 +59,12 @@ public class StompErrorHandler extends StompSubProtocolErrorHandler {
         log.error("[StompErrorHandler] - Error code= {}, message= {}", errorCode.getCode(), errorCode.getMessage());
         StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.ERROR);
 
-        String code = String.valueOf(errorCode.getMessage());
+        String code = errorCode.getMessage();
 
-        accessor.setMessage(String.valueOf(errorCode.getCode()));
+        accessor.setMessage(errorCode.getCode());
         accessor.setLeaveMutable(true);
 
         return MessageBuilder.createMessage(code.getBytes(StandardCharsets.UTF_8), accessor.getMessageHeaders());
     }
-
-
-
-
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,18 @@
 spring:
+  application:
+    name: chat-message
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: kafka-test
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      client-id: chat-api
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+
   data:
     mongodb:
       uri: mongodb://127.0.0.1:27017/gaaji-chat
@@ -8,3 +22,10 @@ spring:
       password: 1234
       test:
         connectionString: mongodb://127.0.0.1:27017/gaaji-chat
+
+eureka:
+  client:
+    register-with-eureka: false
+    fetch-registry: false
+    service-url:
+      defaultZone: http://localhost:8761/eureka


### PR DESCRIPTION
# Description
> GM-69 하위의 GM-107 이슈에 대한 PR임.

기존 에러코드는 Http Status 기반으로 구성하였으나,

Gaaji의 커스텀 에러코드를 구성하자는 이슈를 통해 에러코드를 재정의함.

## Content
변경된 ErrorCode는 다음과 같다.

여기서 말하는 인증 토큰이란 SocketToken을 말한다.

> `global.exception.ErrorCode`  
```
    TOKEN_NULL_ERROR("C-101", "인증 토큰이 없습니다."),
    INVALIDATED_TOKEN_ERROR("C-102", "토큰 검증에 실패하였습니다."),
    MALFORMED_TOKEN_ERROR("C-103", "토큰의 형식이 유효하지 않습니다."),
    TOKEN_EXPIRATION_ERROR("C-104", "인증 토큰이 만료되었습니다."),
    INVALIDATED_TOKEN_PREFIX_ERROR("C-105", "토큰 타입이 유효하지 않습니다."),
    ;
    private String code;
    private String message;
```
