### PR TITLE
[GM-109] 세션 정보 DB 저장

### DIFF
--- a/src/main/java/com/gaaji/chatmessage/domain/entity/Chat.java
+++ b/src/main/java/com/gaaji/chatmessage/domain/entity/Chat.java
@@ -19,7 +19,7 @@ public class Chat {
     private String content;
     private Date createdAt;
 
-    public static Chat of(ChatRequest chatDto) {
+    public static Chat from(ChatRequest chatDto) {
         return Chat.builder()
                 .id(ObjectId.get())
                 .roomId(chatDto.getRoomId())

--- a/src/main/java/com/gaaji/chatmessage/domain/entity/Session.java
+++ b/src/main/java/com/gaaji/chatmessage/domain/entity/Session.java
@@ -1,0 +1,46 @@
+package com.gaaji.chatmessage.domain.entity;
+
+
+import lombok.Builder;
+import lombok.Data;
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.Objects;
+
+@Data
+@Builder
+@Document(collection = "sessions")
+public class Session {
+    private ObjectId id;
+    private String sessionId;
+    private String userId;
+
+    private Session() {}
+    private Session(ObjectId id, String sessionId, String userId) {
+        this.id = id;
+        this.sessionId = sessionId;
+        this.userId = userId;
+    }
+
+    public static Session of(String sessionId, String userId) {
+        return Session.builder()
+                .id(ObjectId.get())
+                .sessionId(sessionId)
+                .userId(userId)
+                .build();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        Session s = (Session) o;
+        return Objects.equals(this.id, s.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return this.id.hashCode();
+    }
+}

--- a/src/main/java/com/gaaji/chatmessage/domain/repository/SessionRepository.java
+++ b/src/main/java/com/gaaji/chatmessage/domain/repository/SessionRepository.java
@@ -1,0 +1,12 @@
+package com.gaaji.chatmessage.domain.repository;
+
+import com.gaaji.chatmessage.domain.entity.Session;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.Optional;
+
+public interface SessionRepository extends MongoRepository<Session, String> {
+
+    Optional<Session> findBySessionId(String sessionId);
+
+}

--- a/src/main/java/com/gaaji/chatmessage/domain/service/ChatServiceImpl.java
+++ b/src/main/java/com/gaaji/chatmessage/domain/service/ChatServiceImpl.java
@@ -18,7 +18,7 @@ public class ChatServiceImpl implements ChatService{
 
     @Override
     public void chat(ChatRequest chatRequest) {
-        Chat chat = Chat.of(chatRequest);
+        Chat chat = Chat.from(chatRequest);
 
         // 1. DB 저장
         chatRepository.save(chat);

--- a/src/test/java/com/gaaji/chatmessage/domain/repository/ChatRepositoryTest.java
+++ b/src/test/java/com/gaaji/chatmessage/domain/repository/ChatRepositoryTest.java
@@ -21,7 +21,7 @@ class ChatRepositoryTest {
 
     private Chat createChat() {
         ChatRequest request = ChatRequest.builder().roomId(roomId).senderId(UUID.randomUUID().toString()).content("hello! new chat!!").build();
-        return Chat.of(request);
+        return Chat.from(request);
     }
 
     @Test


### PR DESCRIPTION
# Description
> GM-109 이슈를 완료하여 main 브랜치로 병합하기 위한 PR임.

## Issue
본 이슈는 기존 Map<String, String> sessions로 유지하던 클라이언트 세션 정보를  

분산된 DB에  저장하고자 하는 이슈다.

- Connect 시, Session을 생성, 저장한 후 Kafka 메시지를 발행한다.

- Disconnect 시, Session을 조회하여 존재하면 삭제한 후 Kafka 메시지를 발행한다.

case **`CONNECT`**
```
    @Override
    public void connect(String sessionId, String userId) {
        Session connectSession = Session.of(sessionId, userId);

        sessionRepository.save(connectSession);

        kafkaService.notifyOnline(userId);
    }
```

case **`DISCONNECT`**
```
    @Override
    public void disconnect(String sessionId) {
        sessionRepository.findBySessionId(sessionId)
                .ifPresent(
                        session -> {
                            kafkaService.notifyOffline(session.getUserId());
                            sessionRepository.delete(session);
                        }
                );
    }
```

## Related Class
`WebSocketConnectService`

`WebSocketConnectServiceImpl`