### PR TITLE
[GM-116] 로직 비동기 처리

### DIFF
--- a/src/main/java/com/gaaji/chatmessage/domain/controller/ChatController.java
+++ b/src/main/java/com/gaaji/chatmessage/domain/controller/ChatController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Controller;
 
 @Slf4j
@@ -14,12 +15,12 @@ import org.springframework.stereotype.Controller;
 @RequiredArgsConstructor
 public class ChatController {
 
+    private final SimpMessageSendingOperations template;
     private final ChatService chatService;
 
     @MessageMapping(ApiConstants.ENDPOINT_CHAT)
-    public void chat(@Payload ChatDto chat) {
-        log.info("CHAT: {}", chat);
-
-        chatService.chat(chat);
+    public void chat(@Payload ChatDto chatDto) {
+        template.convertAndSend(ApiConstants.SUBSCRIBE_ENDPOINT + chatDto.getRoomId(), chatDto);
+        chatService.chat(chatDto);
     }
 }

--- a/src/main/java/com/gaaji/chatmessage/domain/service/ChatServiceImpl.java
+++ b/src/main/java/com/gaaji/chatmessage/domain/service/ChatServiceImpl.java
@@ -3,35 +3,37 @@ package com.gaaji.chatmessage.domain.service;
 import com.gaaji.chatmessage.domain.controller.dto.ChatDto;
 import com.gaaji.chatmessage.domain.entity.Chat;
 import com.gaaji.chatmessage.domain.repository.ChatRepository;
-import com.gaaji.chatmessage.global.constants.ApiConstants;
+import com.gaaji.chatmessage.global.constants.IntegerConstants;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import lombok.RequiredArgsConstructor;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 @Service
 @RequiredArgsConstructor
 public class ChatServiceImpl implements ChatService{
 
-    private final SimpMessageSendingOperations template;
     private final ChatRepository chatRepository;
     private final KafkaService kafkaService;
+    private final ExecutorService kafkaConnectThreadPool =
+            Executors.newFixedThreadPool(IntegerConstants.RUNTIME_CORE_COUNT,
+                    new ThreadFactoryBuilder().setNameFormat("Gaaji-Chat-Kafka-Connect-Thread-%d").build());
+
+    private final ExecutorService databaseConnectThreadPool =
+            Executors.newFixedThreadPool(IntegerConstants.RUNTIME_CORE_COUNT,
+                    new ThreadFactoryBuilder().setNameFormat("Gaaji-Chat-Database-Connect-Thread-%d").build());
 
     @Override
     public void chat(ChatDto chatDto) {
-        Chat chat = Chat.from(chatDto);
+        // Kafka 메시지 발행
+        kafkaConnectThreadPool.submit(() -> kafkaService.chat(chatDto));
 
-        // 1. DB 저장
-        chatRepository.save(chat);
-
-        // 2. 구독자에게 브로드캐스트
-        broadcasting(chatDto);
-
-        // 3. API 서버 메시지 전달
-        kafkaService.chat(chatDto);
-
-    }
-
-    private void broadcasting(ChatDto chat) {
-        template.convertAndSend(ApiConstants.SUBSCRIBE_ENDPOINT + chat.getRoomId(), chat);
+        // DB 저장
+        databaseConnectThreadPool.submit(() -> {
+            Chat chat = Chat.from(chatDto);
+            chatRepository.save(chat);
+        });
     }
 }

--- a/src/main/java/com/gaaji/chatmessage/domain/service/WebSocketConnectServiceImpl.java
+++ b/src/main/java/com/gaaji/chatmessage/domain/service/WebSocketConnectServiceImpl.java
@@ -2,8 +2,13 @@ package com.gaaji.chatmessage.domain.service;
 
 import com.gaaji.chatmessage.domain.entity.Session;
 import com.gaaji.chatmessage.domain.repository.SessionRepository;
+import com.gaaji.chatmessage.global.constants.IntegerConstants;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 @Component
 @RequiredArgsConstructor
@@ -12,13 +17,18 @@ public class WebSocketConnectServiceImpl implements WebSocketConnectService {
     private final SessionRepository sessionRepository;
     private final KafkaService kafkaService;
 
+    private final ExecutorService kafkaConnectThreadPool =
+            Executors.newFixedThreadPool(IntegerConstants.RUNTIME_CORE_COUNT,
+                    new ThreadFactoryBuilder().setNameFormat("Gaaji-Connect-Kafka-Connect-Thread-%d").build());
+
+
     @Override
     public void connect(String sessionId, String userId) {
         Session connectSession = Session.of(sessionId, userId);
-
         sessionRepository.save(connectSession);
 
-        kafkaService.notifyOnline(userId);
+        kafkaConnectThreadPool.submit(() ->
+                kafkaService.notifyOnline(connectSession.getUserId()));
     }
 
     @Override
@@ -26,8 +36,10 @@ public class WebSocketConnectServiceImpl implements WebSocketConnectService {
         sessionRepository.findBySessionId(sessionId)
                 .ifPresent(
                         session -> {
-                            kafkaService.notifyOffline(session.getUserId());
                             sessionRepository.delete(session);
+
+                            kafkaConnectThreadPool.submit(() ->
+                                    kafkaService.notifyOffline(session.getUserId()));
                         }
                 );
     }

--- a/src/main/java/com/gaaji/chatmessage/global/constants/IntegerConstants.java
+++ b/src/main/java/com/gaaji/chatmessage/global/constants/IntegerConstants.java
@@ -1,0 +1,8 @@
+package com.gaaji.chatmessage.global.constants;
+
+public class IntegerConstants {
+
+    /** 시스템 CPU의 최대 가용 코어 수 */
+    public static final int RUNTIME_CORE_COUNT = Runtime.getRuntime().availableProcessors();
+
+}


### PR DESCRIPTION
# Description
> GM-115 하위의 GM-116 이슈에 대한 PR임.

# Issue GM-116
refactor: GM-116 비동기 처리

- Kafka 메시지 발행 및 Chat Db 저장 등 메시지 브로드캐스팅 이외의 작업에 대하여 비동기 처리를 진행
- 비동기 처리를 위해 Java API인 ExecutorService를 이용하여 ThreadPool을 생성하였음.

## ExecutorService
ExecutorService를 이용하면, 개발자가 직접 Thread를 관리할 필요 없이,  
ThreadPool을 생성하고, 이에 속하는 Thread들을 생성, 실행, 소멸해준다.  
  
ExecutorService는 4가지의 ThreadPool을 생성할 수 있다.
1. newSingleThreadExecutor() :  호출 시 ThreadPool에 하나의 Thread를 생성, 관리한다.
2. newCachedThreadPool() : 호출 시 ThreadPool에 Thread를 생성하는데, 사용 후 60초동안 다시 사용하지 않으면 Pool에서 소멸시킨다.
3. newScheduledThreadPool() : 호출 시 ThreadPool에 Thread를 생성하는데, 반복 주기와 같은 로직을 처리하는 Thread를 생성, 관리한다.
4. newFixedThreadPool() : 호출 시 ThreadPool에 Thread를 생성하는데, 파라미터로 Thread 수를 설정하여 이에 맞는 Thread들만 생성, 관리한다.

본인은 newFixedThreadPool()를 사용하여 Thread를 생성하였는데, newCachedThreadPool() 사용 시 무제한적으로 Thread가 생성되기에 오히려 컴퓨팅 성능을 하락시킬 수 있기 때문이다.  

따라서 ThreadPool에 생성될 Thread를 수를 WAS 컴퓨터 CPU의 최대 가용 Core 수로 제한하였다. 이를 IntegerConstants 클래스에서 컴파일 시 static으로 정의하여 전역적으로 사용하도록 하였다.  

`IntegerConstants`
```
    /** 시스템 CPU의 최대 가용 코어 수 */
    public static final int RUNTIME_CORE_COUNT = Runtime.getRuntime().availableProcessors();
```

## 비동기 로직
- 본 프로젝트에서는 ThreadPool은 총 3개가 생성된다.    

`WebSocketConnectServiceImpl`
```
    private final ExecutorService kafkaConnectThreadPool =
            Executors.newFixedThreadPool(IntegerConstants.RUNTIME_CORE_COUNT,
                    new ThreadFactoryBuilder().setNameFormat("Gaaji-Connect-Kafka-Connect-Thread-%d").build());
```

`ChatServiceImpl `
```
    private final ExecutorService kafkaConnectThreadPool =
            Executors.newFixedThreadPool(IntegerConstants.RUNTIME_CORE_COUNT,
                    new ThreadFactoryBuilder().setNameFormat("Gaaji-Chat-Kafka-Connect-Thread-%d").build());

    private final ExecutorService databaseConnectThreadPool =
            Executors.newFixedThreadPool(IntegerConstants.RUNTIME_CORE_COUNT,
                    new ThreadFactoryBuilder().setNameFormat("Gaaji-Chat-Database-Connect-Thread-%d").build());
```
- ThreadPool의 Thread는 IntegerConstants에서 컴파일시 정의되는 현재 시스템 CPU의 최대 가용 코어 수(n)만큼 생성된다.
- 따라서 총 생성되는 Thread는 최대 n * 3이다.

## Test
1. Connect, Disconnect 시 실행되는 로직은 크게 세가지다.
- validate token
- save session data to database
- publish message of kafka  

이 중 로직에서 비동기로 처리해도 되는 Kafka 관련 로직을 비동기로 처리하였다.  
connect 시 토큰 검증, 데이터 저장 이후 클라이언트에게는 Connect 성공을 응답하고, kafka로 connect를 알린다.

`Log`  

![image](https://user-images.githubusercontent.com/42243302/213643747-a0825224-0268-4537-8d4b-fd80184e096f.png)  

`Thread`  

![image](https://user-images.githubusercontent.com/42243302/213643897-03938275-0c17-4e53-8c90-8839a73891fd.png)

> 위 Thread는 connect, disconnect 요청을 각 10번 이상 실행하였을 때의 Thread들이다.

2. 클라이언트 채팅 시 발생하는 로직은 크게 세가지다.
- broadcasting to stomp subscribe
- save chat data to database
- publish message of kafka  

이 중 브로드캐스팅은 main 스레드에서 실행되지만, db 저장 및 kafka 메시지 발행은 별도의 스레드에서 실행하여 비동기 처리하였다.  

`Thread`  

![image](https://user-images.githubusercontent.com/42243302/213644712-fe544203-afd2-4b7a-babb-fd6dd37cc831.png)

> 위 Thread는 chat 요청을 10번 이상 실행하였을 때의 Thread들이다.

# Conclusion
본 Refactor를 통해 connect, chat 요청 시 db 저장, kafka 발행 등의 이유로 발생되던 딜레이를 해결하였다.  

---  


close GM-116