### PR TITLE
[GM-167] 토큰 발급 시 response body로 응답

### DIFF
--- a/src/main/java/com/gaaji/chatmessage/domain/controller/TokenController.java
+++ b/src/main/java/com/gaaji/chatmessage/domain/controller/TokenController.java
@@ -3,7 +3,6 @@ package com.gaaji.chatmessage.domain.controller;
 import com.gaaji.chatmessage.domain.controller.dto.TokenDto;
 import com.gaaji.chatmessage.domain.service.TokenService;
 import com.gaaji.chatmessage.global.constants.ApiConstants;
-import com.gaaji.chatmessage.global.constants.StringConstants;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,7 +22,7 @@ public class TokenController {
     public TokenDto createToken() {
         String token = tokenService.createToken();
 
-        return TokenDto.of(StringConstants.HEADER_SOCKET_TOKEN, token);
+        return TokenDto.of(token);
     }
 
 }

--- a/src/main/java/com/gaaji/chatmessage/domain/controller/TokenController.java
+++ b/src/main/java/com/gaaji/chatmessage/domain/controller/TokenController.java
@@ -1,5 +1,6 @@
 package com.gaaji.chatmessage.domain.controller;
 
+import com.gaaji.chatmessage.domain.controller.dto.TokenDto;
 import com.gaaji.chatmessage.domain.service.TokenService;
 import com.gaaji.chatmessage.global.constants.ApiConstants;
 import com.gaaji.chatmessage.global.constants.StringConstants;
@@ -10,8 +11,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.servlet.http.HttpServletResponse;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping(ApiConstants.ENDPOINT_CHAT)
@@ -21,10 +20,10 @@ public class TokenController {
 
     @GetMapping(ApiConstants.ENDPOINT_CREATE_TOKEN)
     @ResponseStatus(HttpStatus.CREATED)
-    public void createToken(HttpServletResponse response) {
+    public TokenDto createToken() {
         String token = tokenService.createToken();
 
-        response.addHeader(StringConstants.HEADER_SOCKET_TOKEN, token);
+        return TokenDto.of(StringConstants.HEADER_SOCKET_TOKEN, token);
     }
 
 }

--- a/src/main/java/com/gaaji/chatmessage/domain/controller/dto/TokenDto.java
+++ b/src/main/java/com/gaaji/chatmessage/domain/controller/dto/TokenDto.java
@@ -8,8 +8,4 @@ import lombok.*;
 public class TokenDto {
     private final String tokenHeaderName = StringConstants.HEADER_SOCKET_TOKEN;
     private final String token;
-
-//    public static TokenDto of(String token) {
-//        return new TokenDto(StringConstants.HEADER_SOCKET_TOKEN, token);
-//    }
 }

--- a/src/main/java/com/gaaji/chatmessage/domain/controller/dto/TokenDto.java
+++ b/src/main/java/com/gaaji/chatmessage/domain/controller/dto/TokenDto.java
@@ -1,0 +1,13 @@
+package com.gaaji.chatmessage.domain.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor(staticName = "of")
+public class TokenDto {
+    private String tokenHeaderName;
+    private String token;
+}

--- a/src/main/java/com/gaaji/chatmessage/domain/controller/dto/TokenDto.java
+++ b/src/main/java/com/gaaji/chatmessage/domain/controller/dto/TokenDto.java
@@ -1,13 +1,15 @@
 package com.gaaji.chatmessage.domain.controller.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import com.gaaji.chatmessage.global.constants.StringConstants;
+import lombok.*;
 
 @Data
-@NoArgsConstructor
-@AllArgsConstructor(staticName = "of")
+@RequiredArgsConstructor(staticName = "of")
 public class TokenDto {
-    private String tokenHeaderName;
-    private String token;
+    private final String tokenHeaderName = StringConstants.HEADER_SOCKET_TOKEN;
+    private final String token;
+
+//    public static TokenDto of(String token) {
+//        return new TokenDto(StringConstants.HEADER_SOCKET_TOKEN, token);
+//    }
 }


### PR DESCRIPTION
# [GM-167] 토큰 발급 시 response body로 응답
## Description
> 채팅 메시지 서버의 웹소켓 토큰 시, 기존에는 response header에 토큰을 응답하였지만, body로 응답하는 것으로 변경하였다.

## PR Type
- [ ] Hotfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [ ] Infra (cloud, security, etc.)
- [ ] Other... Please describe :

## Related Issues
- GM-160

## Issues
### TokenDto
> response body에 담길 DTO 클래스를 생성하였다. DTO에는 Stomp 헤더에 추가될 토큰 헤더 이름과 토큰 값이 저장된다.

```java
@Data
@RequiredArgsConstructor(staticName = "of")
public class TokenDto {
    private final String tokenHeaderName = StringConstants.HEADER_SOCKET_TOKEN;
    private final String token;
}
```

### TokenController
> 기존 response.addHeader()가 아닌 DTO를 리턴하는 메소드로 변경하였다.

```java
    @GetMapping(ApiConstants.ENDPOINT_CREATE_TOKEN)
    @ResponseStatus(HttpStatus.CREATED)
    public TokenDto createToken() {
        String token = tokenService.createToken();

        return TokenDto.of(token);
    }
```

### Test

![image](https://user-images.githubusercontent.com/42243302/215412226-52943ba9-7570-4e0f-9f7f-09f72c24a40e.png)

*** 

## Related Files
- `TokenDto`
- `TokenController`

## Think About..  

## Conclusion  
> close GM-167
